### PR TITLE
Add CoC v1

### DIFF
--- a/coc/README.md
+++ b/coc/README.md
@@ -1,0 +1,59 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as pledge to
+making participation in our project and our community a harassment-free
+experience for everyone, regardless of age, body size, disability, ethnicity,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Community admins are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Also have the right and responsibility to remove, edit, or reject comments and
+other contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any member for other behaviors that they deem
+inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at bcneng@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The admin team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/coc/README.md
+++ b/coc/README.md
@@ -5,9 +5,9 @@
 In the interest of fostering an open and welcoming environment, we as pledge to
 making participation in our project and our community a harassment-free
 experience for everyone, regardless of age, body size, disability, ethnicity,
-gender identity and expression, level of experience, technology, education,
-socio-economic status, nationality, personal appearance, race, religion, or
-sexual identity and orientation.
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
 
 ## Our Standards
 


### PR DESCRIPTION
This is almost a copy of https://www.contributor-covenant.org/version/1/4/code-of-conduct.html.

The objective of this PR is to improve the presented CoC to be suitable for the BcnEng community.

Comments and even PRs to the `add/coc` are more than necessary & welcome.